### PR TITLE
Don't override bonuseffect if it already set

### DIFF
--- a/scripting/tf_ontakedamage.sp
+++ b/scripting/tf_ontakedamage.sp
@@ -187,11 +187,10 @@ public MRESReturn Internal_OnTakeDamageAlive(int victim, Handle hReturn, Handle 
 }
 
 public Action OnPlayerHurt(Event event, const char[] name, bool dontBroadcast) {
-	if (g_ContextCritType != 1) {
+	if (g_ContextCritType != 1 || event.GetInt("bonuseffect") != 4) {
 		return Plugin_Continue;
 	}
 	
-	event.SetInt("crit", 1);
 	event.SetInt("minicrit", 1);
 	event.SetInt("bonuseffect", 1);
 	return Plugin_Changed;


### PR DESCRIPTION
- As I mentioned long time ago in Issue #2, Setting `bonuseffect` to `1` make minicrit effect.
- And If the value of the `bonuseffect` is `4(kBonusEffect_None)`, it's enough to change that value, and you don't have to set the value of the `crit`.
- Still random critical or critical on kill, etc. are using `4(kBonusEffect_None)`, but current logic doesn't conflict with them.
- As a result, there is no side or bad effect of this. I tested this for long time.

Closes #2.