### PR TITLE
Mitigate warning & compilation error on spcomp >=1.11

### DIFF
--- a/scripting/templates/class.ms.sp
+++ b/scripting/templates/class.ms.sp
@@ -63,12 +63,6 @@ methodmap {{classname}}{{#inherits}} < {{inherits}}{{/inherits}} {
 		return view_as<{{classname}}>(pInstance);
 	}
 	
-	/**
-	 * Developers may want to implement their own methods on this methodmap; they can be
-	 * automatically included here.
-	 */
-	#tryinclude "classmethods/{{classname}}.sp"
-	
 	property Address Address {
 		public get() {
 			return view_as<Address>(this);

--- a/scripting/tf_ontakedamage.sp
+++ b/scripting/tf_ontakedamage.sp
@@ -184,6 +184,8 @@ void CallTakeDamageInfoPostForward(Handle fwd, int victim, CTakeDamageInfo info)
 public MRESReturn Internal_OnTakeDamageAlive(int victim, Handle hReturn, Handle hParams) {
 	CTakeDamageInfo info = CTakeDamageInfo.FromAddress(DHookGetParam(hParams, 1));
 	g_ContextCritType = info.m_eCritType;
+
+	return MRES_Ignored;
 }
 
 public Action OnPlayerHurt(Event event, const char[] name, bool dontBroadcast) {


### PR DESCRIPTION
As issue https://github.com/nosoop/SM-TFOnTakeDamage/issues/7 points out, using spcomp >=1.11 breaks compilation of this plugin. All I did is remove the `#tryinclude` directive from class.ms.sp, like the plugin author pointed the issue author to do.
This successfully makes the plugin compile on spcomp 1.11.0.6952 + ninja.

This should probably be merged as sourcemod 1.11 is the current stable version that people will download moving on.

I also added a return statement to tf_ontakedamage.sp's Internal_OnTakeDamageAlive, to suppress a warning from spcomp, which says a function needs to return something.

I tested this change with a compiled ontakedamage_forcecrits.sp, and the plugin works fine. If MRES_Ignored is the wrong statement, please correct it, or remove it entirely if the compiler warning is fine.